### PR TITLE
[WIP] Added author to the searchable terms if it exists

### DIFF
--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -66,7 +66,8 @@ export default function ListLayout({
 }: ListLayoutProps) {
   const [searchValue, setSearchValue] = useState('')
   const filteredBlogPosts = posts.filter((post) => {
-    const searchContent = post.title + post.summary + post.tags.join(' ')
+    const searchContent =
+      post.title + post.summary + post.tags.join(' ') + (post.authors && post.authors.join(' '))
     return searchContent.toLowerCase().includes(searchValue.toLowerCase())
   })
 


### PR DESCRIPTION
Working on making authors more searchable

- Have added the author field to searchable terms (if it exists on the blog's frontmatter).

Todo:
- Figure out how to input a search term into the blog post search and link to that - fill in with search term? Look into how clicking Tags implements this because that seems to work exactly how I want this feature to work.