### PR TITLE
Feature/add author search page

### DIFF
--- a/pages/authors/[author].tsx
+++ b/pages/authors/[author].tsx
@@ -1,12 +1,11 @@
 import { TagSEO } from '@/components/SEO'
 import siteMetadata from '@/data/siteMetadata'
 import ListLayout from '@/layouts/ListLayout'
-// import { kebabCase } from 'pliny/utils/kebabCase'
 import { allCoreContent } from 'pliny/utils/contentlayer'
 import { getAllAuthors } from 'src/getAllAuthors'
 import { InferGetStaticPropsType } from 'next'
 import { allBlogs, allAuthors } from 'contentlayer/generated'
-console.log(allAuthors)
+
 export async function getStaticPaths() {
   const authors = await getAllAuthors(allBlogs)
 
@@ -32,8 +31,9 @@ export const getStaticProps = async (context) => {
 }
 
 export default function Author({ posts, author }: InferGetStaticPropsType<typeof getStaticProps>) {
-  // Capitalize first letter and convert space to dash
-  const title = author[0].toUpperCase() //+ author.split(' ').join('-').slice(1)
+  // Find author in author data (allAuthors) matching on username first (e.g. sparrowhawk) to pull full name (e.g. 'Sparrow Hawk')
+  const author_full_name = allAuthors.filter((i) => i.slug.includes(author))[0].name
+  const title = author_full_name + "'s posts"
   return (
     <>
       <TagSEO

--- a/pages/authors/[author].tsx
+++ b/pages/authors/[author].tsx
@@ -1,0 +1,46 @@
+import { TagSEO } from '@/components/SEO'
+import siteMetadata from '@/data/siteMetadata'
+import ListLayout from '@/layouts/ListLayout'
+// import { kebabCase } from 'pliny/utils/kebabCase'
+import { allCoreContent } from 'pliny/utils/contentlayer'
+import { getAllAuthors } from 'src/getAllAuthors'
+import { InferGetStaticPropsType } from 'next'
+import { allBlogs, allAuthors } from 'contentlayer/generated'
+console.log(allAuthors)
+export async function getStaticPaths() {
+  const authors = await getAllAuthors(allBlogs)
+
+  return {
+    paths: Object.keys(authors).map((author) => ({
+      params: {
+        author,
+      },
+    })),
+    fallback: false,
+  }
+}
+
+export const getStaticProps = async (context) => {
+  const author = context.params.author as string
+  const filteredPosts = allCoreContent(
+    allBlogs.filter(
+      (post) => post.draft !== true && post.authors && post.authors.includes(author) // .map((t) => kebabCase(t))
+    )
+  )
+
+  return { props: { posts: filteredPosts, author } }
+}
+
+export default function Author({ posts, author }: InferGetStaticPropsType<typeof getStaticProps>) {
+  // Capitalize first letter and convert space to dash
+  const title = author[0].toUpperCase() //+ author.split(' ').join('-').slice(1)
+  return (
+    <>
+      <TagSEO
+        title={`${author} - ${siteMetadata.title}`}
+        description={`${author} posts - ${siteMetadata.author}`}
+      />
+      <ListLayout posts={posts} title={title} />
+    </>
+  )
+}

--- a/pages/tags/[tag].tsx
+++ b/pages/tags/[tag].tsx
@@ -5,7 +5,7 @@ import { kebabCase } from 'pliny/utils/kebabCase'
 import { getAllTags, allCoreContent } from 'pliny/utils/contentlayer'
 import { InferGetStaticPropsType } from 'next'
 import { allBlogs } from 'contentlayer/generated'
-
+console.log(allBlogs)
 export async function getStaticPaths() {
   const tags = await getAllTags(allBlogs)
 

--- a/src/getAllAuthors.d.ts
+++ b/src/getAllAuthors.d.ts
@@ -1,0 +1,3 @@
+declare function getAllAuthors(allBlogs: MDXBlog[]): Promise<Record<string, number>>
+
+export { getAllAuthors }

--- a/src/getAllAuthors.js
+++ b/src/getAllAuthors.js
@@ -1,0 +1,20 @@
+import GithubSlugger from 'github-slugger'
+
+async function getAllAuthors(allBlogs) {
+  const authorCount = {}
+  allBlogs.forEach((file) => {
+    if (file.authors && file.draft !== true) {
+      file.authors.forEach((author) => {
+        const formattedAuthor = GithubSlugger.slug(author)
+        if (formattedAuthor in authorCount) {
+          authorCount[formattedAuthor] += 1
+        } else {
+          authorCount[formattedAuthor] = 1
+        }
+      })
+    }
+  })
+  return authorCount
+}
+
+export { getAllAuthors }


### PR DESCRIPTION
Added a parameterised authors page in a similar fashion to the [tag].tsx page.

Access/test by going to /authors/sparrowhawk or /authors/default. Will lookup the author's username and find their full name to display as the title of the blog post list.