### PR TITLE
Added DM Mono font, changed font to mono for Tag links, info header o…

### DIFF
--- a/components/MultiPartTracker.tsx
+++ b/components/MultiPartTracker.tsx
@@ -23,7 +23,7 @@ const MultiPartTracker = ({ path, allPosts }: TrackerProps) => {
         {filteredBlogs.map((post, index) => (
           <li key={index}>
             <div className="flex items-center">
-              <div className="mr-[0.5rem] w-6 flex-shrink-0 text-center text-gray-500">
+              <div className="mono mr-[0.5rem] w-6 flex-shrink-0 text-center text-gray-500">
                 {index + 1}
               </div>
               <div className="posts-in-series min-w-0">

--- a/components/Tag.tsx
+++ b/components/Tag.tsx
@@ -7,7 +7,10 @@ interface Props {
 
 const Tag = ({ text }: Props) => {
   return (
-    <Link href={`/tags/${kebabCase(text)}`} className="tag-link mr-3 text-sm font-medium uppercase">
+    <Link
+      href={`/tags/${kebabCase(text)}`}
+      className="mono tag-link mr-3 text-sm font-medium uppercase"
+    >
       {text.split(' ').join('-')}
     </Link>
   )

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -36,6 +36,14 @@
   @apply text-primary-500 duration-300
 }
 
+.mono {
+  font-family: 'DM Mono', sans-serif;
+}
+
+.light {
+  font-weight: lighter;
+}
+
 .tag-link:hover {
   @apply text-primary-600 dark:text-primary-400
 }

--- a/data/blog/abs-robust-regression.mdx
+++ b/data/blog/abs-robust-regression.mdx
@@ -12,7 +12,7 @@ authors: ['darrenwong', 'vincentdoan', 'brandonhao']
 
 ![](/static/images/abs-robust-reg/robust_regression_varying_c.gif)
 
-<p style={{ fontStyle: 'italic', textAlign: 'center' }}>The effects of varying the outlier threshold on robust regression fit and forecast</p>
+<p className="mono tracking-tighter" style={{ fontStyle: 'italic', textAlign: 'center' }}>The effects of varying the outlier threshold on robust regression fit and forecast</p>
 
 # Introduction
 

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -63,7 +63,7 @@ export default function PostLayout({
               <dl className="space-y-10">
                 <div>
                   <dt className="sr-only">Published on</dt>
-                  <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
+                  <dd className="mono text-base font-medium leading-6 tracking-tight text-gray-500 dark:text-gray-400">
                     <time dateTime={date}>
                       {new Date(date).toLocaleDateString(siteMetadata.locale, postDateTemplate)}
                     </time>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "starter-blog",
       "version": "0.0.1",
       "dependencies": {
+        "@fontsource/dm-mono": "^5.0.1",
         "@next/bundle-analyzer": "13.1.6",
         "@next/font": "13.1.6",
         "@tailwindcss/forms": "^0.5.3",
@@ -2667,6 +2668,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz",
       "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ=="
+    },
+    "node_modules/@fontsource/dm-mono": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@fontsource/dm-mono/-/dm-mono-5.0.1.tgz",
+      "integrity": "sha512-q4cWi6uf9PCgWVnur9+7RsAvXBc6aPEm/XI4rJ6YuvNCG4KWO9VSBA6+DnVVxnlNrWypRlxhvQy2D+o/OpQ4KA=="
     },
     "node_modules/@grpc/grpc-js": {
       "version": "1.8.11",
@@ -16366,6 +16372,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@fal-works/esbuild-plugin-global-externals/-/esbuild-plugin-global-externals-2.1.2.tgz",
       "integrity": "sha512-cEee/Z+I12mZcFJshKcCqC8tuX5hG3s+d+9nZ3LabqKF1vKdF41B92pJVCBggjAGORAeOzyyDDKrZwIkLffeOQ=="
+    },
+    "@fontsource/dm-mono": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@fontsource/dm-mono/-/dm-mono-5.0.1.tgz",
+      "integrity": "sha512-q4cWi6uf9PCgWVnur9+7RsAvXBc6aPEm/XI4rJ6YuvNCG4KWO9VSBA6+DnVVxnlNrWypRlxhvQy2D+o/OpQ4KA=="
     },
     "@grpc/grpc-js": {
       "version": "1.8.11",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint --fix --dir pages --dir components --dir lib --dir layouts --dir scripts"
   },
   "dependencies": {
+    "@fontsource/dm-mono": "^5.0.1",
     "@next/bundle-analyzer": "13.1.6",
     "@next/font": "13.1.6",
     "@tailwindcss/forms": "^0.5.3",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,9 @@
 import '@/css/tailwind.css'
 import '@/css/prism.css'
 import 'katex/dist/katex.css'
+import '@fontsource/dm-mono/300.css'
+import '@fontsource/dm-mono/400.css'
+import '@fontsource/dm-mono/500.css'
 // import '@/css/docsearch.css' // Uncomment if using algolia docsearch
 // import '@docsearch/css' // Uncomment if using algolia docsearch
 


### PR DESCRIPTION
Adding monospace font ([DM Mono](https://fontsource.org/fonts/dm-mono)) while attempting to keep things minimal and not too distracting.

For now the font change is limited to:
* The info header on each article
* Tag links
* Image captions

<img width="1101" alt="image" src="https://github.com/herd-mentality/hm_blog/assets/74039081/65780893-06ca-4705-b9c6-e23c4b8eb2fb">
<img width="1071" alt="image" src="https://github.com/herd-mentality/hm_blog/assets/74039081/677a4302-28a9-4051-aaf4-d3d2814ede58">
