### PR TITLE
POST Auto Search minScore correction (0.3 -> 0.4)

### DIFF
--- a/data/blog/auto-search.mdx
+++ b/data/blog/auto-search.mdx
@@ -201,7 +201,7 @@ Recall@1 of 0.85 means one query in seven still misses on the top hit. The dropd
 
 ## Lessons learnt
 
-The threshold matters more than the model. `minScore = 0.3` was set by eyeballing the score distribution on the secondary test set. Too high and good matches get suppressed. Too low and the dropdown fills with confident-looking nonsense. This needs revisiting any time the model or corpus shifts.
+The threshold matters more than the model. `minScore = 0.4` was set by eyeballing the score distribution on the secondary test set. Too high and good matches get suppressed. Too low and the dropdown fills with confident-looking nonsense. This needs revisiting any time the model or corpus shifts.
 
 The LLM holdout overstates performance. Recall@1 on it is 0.93, on the secondary test set 0.85. The gap is what the model learned about Claude's verbose conversational phrasing rather than the shorter keyword-style phrasing in the secondary set. The 0.85 is the one worth quoting, and even that is a synthetic proxy until real-user logs exist.
 


### PR DESCRIPTION
## Summary

- Correct `minScore` threshold in the Lessons Learnt section from `0.3` to `0.4` to match the actual config default

## Why

The blog post and the slides both said `minScore = 0.3` but the actual default in `examples/*/config.yaml` and `AutoSearchConfig.java` is `0.4`. Surfaced during a tier-4 review of the auto-search repo. Slides are being updated in the same pass (talk is this Friday).

## Test plan

- [ ] Visual check that the corrected line renders correctly on a local `npm run dev`
- [ ] Merge to main, then open the deploy PR (main → deploy) to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)