### PR TITLE
fix: removed pliny search since it was breaking SSG

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,7 +14,6 @@ import Head from 'next/head'
 
 import siteMetadata from '@/data/siteMetadata'
 // import { Analytics } from 'pliny/analytics'
-import { SearchProvider } from 'pliny/search'
 import LayoutWrapper from '@/components/LayoutWrapper'
 import { useEffect } from 'react'
 import { useRouter } from 'next/router'
@@ -53,9 +52,7 @@ export default function App({ Component, pageProps }: AppProps) {
         hideHeader={Boolean(PageComponent.hideHeader)}
         fullWidthMain={Boolean(PageComponent.fullWidthMain)}
       >
-        <SearchProvider searchConfig={siteMetadata.search}>
-          <PageComponent {...pageProps} />
-        </SearchProvider>
+        <PageComponent {...pageProps} />
       </LayoutWrapper>
     </ThemeProvider>
   )


### PR DESCRIPTION
Removed pliny's `SearchProvider` wrapper from `pages/_app.tsx`. It was wrapping every `<PageComponent>` in a `dynamic(..., { ssr: false })` boundary, which excluded every page's body and head from SSG output. `CommandPalette.tsx` already wires kbar directly, so pliny's provider was both redundant and destructive. This is likely to be the cause of issues with Google crawling and indexing the site.