### PR TITLE
fix(seo): single homepage h1 + richer site description

### DIFF
--- a/data/siteMetadata.js
+++ b/data/siteMetadata.js
@@ -5,7 +5,8 @@ const siteMetadata = {
   title: 'The Herd Mentality',
   author: 'Herd Mentality',
   headerTitle: 'The Herd Mentality',
-  description: 'See the latest posts from the Herd',
+  description:
+    'The Herd Mentality is a technical blog on data science, statistics, machine learning, R, and software engineering, with hands-on tutorials and write-ups.',
   language: 'en-us',
   theme: 'system', // system, dark or light
   siteUrl: 'https://www.herdmentality.xyz',

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -43,9 +43,9 @@ export default function Home({ posts }: InferGetStaticPropsType<typeof getStatic
       <SectionContainer>
         <div id="latest" className="divide-y divide-gray-200 dark:divide-gray-700">
           <div className="space-y-2 pt-32 pb-8 md:space-y-5">
-            <h1 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
+            <h2 className="text-3xl font-extrabold leading-9 tracking-tight text-gray-900 dark:text-gray-100 sm:text-4xl sm:leading-10 md:text-6xl md:leading-14">
               Latest
-            </h1>
+            </h2>
             <p className="font-grotesk text-lg leading-7 text-gray-500 dark:text-gray-400">
               See the latest posts from the Herd
               <UseKeyHint />


### PR DESCRIPTION
- Demote homepage "Latest" heading from h1 to h2 so the page has one descriptive h1 (the Masthead title); resolves Bing's multiple-h1 noise.
- Expand siteMetadata.description (34 -> 153 chars, keyword-rich) for better SERP snippets. Shared by homepage, /blog index, and RSS feed.